### PR TITLE
Fix Cloudflare Pages deploy by removing unsupported build config

### DIFF
--- a/fvbadvocaten/wrangler.toml
+++ b/fvbadvocaten/wrangler.toml
@@ -1,6 +1,3 @@
 name = "fvbadvocaten"
 compatibility_date = "2024-01-01"
 pages_build_output_dir = "out"
-
-[build]
-command = "npm run build"

--- a/fvbarbitration/wrangler.toml
+++ b/fvbarbitration/wrangler.toml
@@ -1,6 +1,3 @@
 name = "fvbarbitration"
 compatibility_date = "2024-01-01"
 pages_build_output_dir = "out"
-
-[build]
-command = "npm run build"

--- a/fvbmediation/wrangler.toml
+++ b/fvbmediation/wrangler.toml
@@ -1,6 +1,3 @@
 name = "fvbmediation"
 compatibility_date = "2024-01-01"
 pages_build_output_dir = "out"
-
-[build]
-command = "npm run build"


### PR DESCRIPTION
## Summary
- Remove `[build]` section from all three `wrangler.toml` files (fvbmediation, fvbadvocaten, fvbarbitration)
- Cloudflare Pages does not support the `build` configuration in `wrangler.toml` — this was causing all deployments to fail with: `Configuration file for Pages projects does not support "build"`
- The build step is already handled by GitHub Actions (`npm run build`), so this section was redundant

## Test plan
- [ ] Merge and verify the GitHub Actions workflow deploys successfully
- [ ] Check https://fvbmediation.pages.dev/ loads correctly
- [ ] Check https://fvbadvocaten.pages.dev/ loads correctly
- [ ] Check https://fvbarbitration.pages.dev/ loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)