### PR TITLE
Move incasso/leasing to praktijkgebieden, add vacatures button, full-screen heroes

### DIFF
--- a/fvbadvocaten/src/app/[locale]/page.tsx
+++ b/fvbadvocaten/src/app/[locale]/page.tsx
@@ -60,7 +60,7 @@ export default async function HomePage({
       <section id="praktijkgebieden" className="bg-steel-100 py-20">
         <Container>
           <SectionHeading>{t.practiceAreas.title}</SectionHeading>
-          <div className="grid gap-10 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
+          <div className="grid gap-10 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
             {t.practiceAreas.areas.map((area) => (
               <PracticeAreaCard key={area.title} {...area} />
             ))}
@@ -218,24 +218,6 @@ export default async function HomePage({
                 </div>
               </div>
             </div>
-          </div>
-        </Container>
-      </section>
-
-      {/* Services highlight strip */}
-      <section className="bg-navy-700 py-20 text-white">
-        <Container>
-          <div className="grid gap-12 md:grid-cols-3">
-            {t.services.items.map((svc) => (
-              <div key={svc.title} className="text-center">
-                <h3 className="font-heading mb-3 text-xl font-bold">
-                  {svc.title}
-                </h3>
-                <p className="text-sm leading-relaxed text-white/70">
-                  {svc.description}
-                </p>
-              </div>
-            ))}
           </div>
         </Container>
       </section>

--- a/fvbadvocaten/src/components/Header.tsx
+++ b/fvbadvocaten/src/components/Header.tsx
@@ -32,7 +32,7 @@ export default function Header({ locale }: { locale: Locale }) {
         </Link>
 
         <div className="hidden items-center gap-8 md:flex">
-          <nav aria-label={locale === "en" ? "Main navigation" : locale === "fr" ? "Navigation principale" : "Hoofdnavigatie"} className="flex gap-8">
+          <nav aria-label={locale === "en" ? "Main navigation" : locale === "fr" ? "Navigation principale" : "Hoofdnavigatie"} className="flex items-center gap-8">
             {navLinks.map((link) => (
               <Link
                 key={link.href}
@@ -42,6 +42,12 @@ export default function Header({ locale }: { locale: Locale }) {
                 {link.label}
               </Link>
             ))}
+            <Link
+              href={`/${locale}/contact/`}
+              className="bg-accent rounded-md px-4 py-2 text-sm font-medium tracking-wide text-white transition hover:bg-accent/80"
+            >
+              {t.nav.vacatures}
+            </Link>
           </nav>
           <LanguageSwitcher locale={locale} />
         </div>
@@ -67,6 +73,13 @@ export default function Header({ locale }: { locale: Locale }) {
               {link.label}
             </Link>
           ))}
+          <Link
+            href={`/${locale}/contact/`}
+            onClick={() => setMobileOpen(false)}
+            className="bg-accent mt-2 block rounded-md px-4 py-3 text-center text-sm font-medium tracking-wide text-white transition hover:bg-accent/80"
+          >
+            {t.nav.vacatures}
+          </Link>
           <div className="border-navy-700 mt-2 border-t pt-3">
             <LanguageSwitcher locale={locale} />
           </div>

--- a/fvbadvocaten/src/components/Hero.tsx
+++ b/fvbadvocaten/src/components/Hero.tsx
@@ -6,7 +6,7 @@ export default function Hero({ locale }: { locale: Locale }) {
   const t = getDictionary(locale);
 
   return (
-    <section className="relative flex min-h-[70vh] items-center justify-center overflow-hidden">
+    <section className="relative flex min-h-screen items-center justify-center overflow-hidden">
       <Image
         src="/images/hero-courthouse.jpg"
         alt={locale === "en" ? "Courthouse Antwerp" : locale === "fr" ? "Palais de justice Anvers" : "Gerechtsgebouw Antwerpen"}

--- a/fvbadvocaten/src/components/PracticeAreaCard.tsx
+++ b/fvbadvocaten/src/components/PracticeAreaCard.tsx
@@ -9,6 +9,8 @@ import {
   Gavel,
   Truck,
   ShieldCheck,
+  Banknote,
+  FileText,
 } from "lucide-react";
 
 const iconMap: Record<string, React.ElementType> = {
@@ -22,6 +24,8 @@ const iconMap: Record<string, React.ElementType> = {
   Gavel,
   Truck,
   ShieldCheck,
+  Banknote,
+  FileText,
 };
 
 export default function PracticeAreaCard({

--- a/fvbadvocaten/src/lib/i18n.ts
+++ b/fvbadvocaten/src/lib/i18n.ts
@@ -26,6 +26,7 @@ function nl() {
       practiceAreas: "Praktijkgebieden",
       whoIsWho: "Wie is wie",
       contact: "Contact",
+      vacatures: "Vacatures",
     },
     hero: { subtitle: "Advocatenkantoor" },
     mission: {
@@ -46,6 +47,8 @@ function nl() {
         { title: "Strafrecht", icon: "Gavel", description: "Verdediging in strafzaken, bijstand bij verhoor, slachtofferbijstand." },
         { title: "Transportrecht", icon: "Truck", description: "Juridisch advies bij transportgeschillen, CMR-vervoer, maritiem recht en logistiek." },
         { title: "Verzekeringsrecht", icon: "ShieldCheck", description: "Advies bij verzekeringsgeschillen, polisinterpretatie en schadeclaims." },
+        { title: "Incasso", icon: "Banknote", description: "Efficiënte invordering van onbetaalde facturen en schuldvorderingen. Wij zorgen voor een snelle en doeltreffende afhandeling van uw incassodossiers." },
+        { title: "Leasingmaatschappijen", icon: "FileText", description: "Gespecialiseerde juridische bijstand voor leasingmaatschappijen. Van contractopstelling tot geschillenbeslechting." },
       ],
     },
     whoIsWho: {
@@ -89,13 +92,6 @@ function nl() {
         role: "Administratie & Office Manager",
         bio: "Kaylee staat het team op administratief en organisatorisch vlak bij. Door haar accuratesse en stiptheid is zij een absolute meerwaarde voor het kantoor.",
       },
-    },
-    services: {
-      items: [
-        { title: "Incasso", description: "Efficiënte invordering van onbetaalde facturen en schuldvorderingen. Wij zorgen voor een snelle en doeltreffende afhandeling van uw incassodossiers." },
-        { title: "Leasingmaatschappijen", description: "Gespecialiseerde juridische bijstand voor leasingmaatschappijen. Van contractopstelling tot geschillenbeslechting." },
-        { title: "Vacatures", description: "Geïnteresseerd om deel uit te maken van ons team? Neem contact met ons op voor meer informatie over openstaande vacatures." },
-      ],
     },
     contact: {
       title: "Contact",
@@ -154,6 +150,7 @@ function en() {
       practiceAreas: "Practice Areas",
       whoIsWho: "Our Team",
       contact: "Contact",
+      vacatures: "Careers",
     },
     hero: { subtitle: "Law Firm" },
     mission: {
@@ -174,6 +171,8 @@ function en() {
         { title: "Criminal Law", icon: "Gavel", description: "Defence in criminal cases, assistance during interrogation, victim support." },
         { title: "Transport Law", icon: "Truck", description: "Legal advice on transport disputes, CMR carriage, maritime law and logistics." },
         { title: "Insurance Law", icon: "ShieldCheck", description: "Advice on insurance disputes, policy interpretation and damage claims." },
+        { title: "Debt Collection", icon: "Banknote", description: "Efficient recovery of unpaid invoices and debts. We ensure a quick and effective handling of your collection cases." },
+        { title: "Leasing Companies", icon: "FileText", description: "Specialised legal assistance for leasing companies. From contract drafting to dispute resolution." },
       ],
     },
     whoIsWho: {
@@ -217,13 +216,6 @@ function en() {
         role: "Administration & Office Manager",
         bio: "Kaylee supports the team in administrative and organisational matters. Through her accuracy and punctuality she is an absolute asset to the firm.",
       },
-    },
-    services: {
-      items: [
-        { title: "Debt Collection", description: "Efficient recovery of unpaid invoices and debts. We ensure a quick and effective handling of your collection cases." },
-        { title: "Leasing Companies", description: "Specialised legal assistance for leasing companies. From contract drafting to dispute resolution." },
-        { title: "Careers", description: "Interested in joining our team? Contact us for more information about open positions." },
-      ],
     },
     contact: {
       title: "Contact",
@@ -282,6 +274,7 @@ function fr() {
       practiceAreas: "Domaines",
       whoIsWho: "Notre équipe",
       contact: "Contact",
+      vacatures: "Offres d'emploi",
     },
     hero: { subtitle: "Cabinet d'avocats" },
     mission: {
@@ -302,6 +295,8 @@ function fr() {
         { title: "Droit pénal", icon: "Gavel", description: "Défense en matière pénale, assistance lors d'interrogatoires, aide aux victimes." },
         { title: "Droit des transports", icon: "Truck", description: "Conseil juridique en matière de litiges de transport, transport CMR, droit maritime et logistique." },
         { title: "Droit des assurances", icon: "ShieldCheck", description: "Conseil en matière de litiges d'assurance, interprétation de polices et réclamations de dommages." },
+        { title: "Recouvrement", icon: "Banknote", description: "Recouvrement efficace des factures impayées et des créances. Nous assurons un traitement rapide et efficace de vos dossiers de recouvrement." },
+        { title: "Sociétés de leasing", icon: "FileText", description: "Assistance juridique spécialisée pour les sociétés de leasing. De la rédaction de contrats à la résolution de litiges." },
       ],
     },
     whoIsWho: {
@@ -345,13 +340,6 @@ function fr() {
         role: "Administration & Office Manager",
         bio: "Kaylee soutient l'équipe sur le plan administratif et organisationnel. Par sa précision et sa ponctualité, elle est un atout absolu pour le cabinet.",
       },
-    },
-    services: {
-      items: [
-        { title: "Recouvrement", description: "Recouvrement efficace des factures impayées et des créances. Nous assurons un traitement rapide et efficace de vos dossiers de recouvrement." },
-        { title: "Sociétés de leasing", description: "Assistance juridique spécialisée pour les sociétés de leasing. De la rédaction de contrats à la résolution de litiges." },
-        { title: "Offres d'emploi", description: "Intéressé à rejoindre notre équipe ? Contactez-nous pour plus d'informations sur les postes vacants." },
-      ],
     },
     contact: {
       title: "Contact",

--- a/fvbarbitration/src/components/Hero.tsx
+++ b/fvbarbitration/src/components/Hero.tsx
@@ -6,7 +6,7 @@ export default function Hero({ locale }: { locale: Locale }) {
   const t = getDictionary(locale);
 
   return (
-    <section className="relative flex min-h-[70vh] items-center justify-center overflow-hidden">
+    <section className="relative flex min-h-screen items-center justify-center overflow-hidden">
       <Image
         src="/images/hero-harbor.png"
         alt={locale === "en" ? "Port of Antwerp" : locale === "fr" ? "Port d'Anvers" : "Haven van Antwerpen"}

--- a/fvbmediation/src/components/Hero.tsx
+++ b/fvbmediation/src/components/Hero.tsx
@@ -6,7 +6,7 @@ export default function Hero({ locale }: { locale: Locale }) {
   const t = getDictionary(locale);
 
   return (
-    <section className="relative flex min-h-[70vh] items-center justify-center overflow-hidden">
+    <section className="relative flex min-h-screen items-center justify-center overflow-hidden">
       <Image
         src="/images/hero-crane.jpg"
         alt={locale === "en" ? "Antwerp construction cranes" : locale === "fr" ? "Grues de construction Anvers" : "Antwerpen bouwkranen"}


### PR DESCRIPTION
## Summary

- Moved Incasso and Leasingmaatschappijen from the services section into praktijkgebieden (practice areas) with icons, across all 3 languages (NL/EN/FR).
- Added a Vacatures button to the fvbadvocaten navigation bar (desktop + mobile) that links directly to the contact page.
- Changed hero sections from 70vh to full-screen height on all 3 sites (fvbadvocaten, fvbmediation, fvbarbitration).
- Removed the now-empty services highlight strip from the homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)