### PR TITLE
Separate incasso/leasing blocks, vacatures link, Unosend contact emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.wrangler/

--- a/fvbadvocaten/functions/api/contact.ts
+++ b/fvbadvocaten/functions/api/contact.ts
@@ -1,4 +1,6 @@
-interface Env {}
+interface Env {
+  UNOSEND_API_KEY: string;
+}
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
   try {
@@ -15,16 +17,41 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       );
     }
 
-    // TODO: Configure email sending via Cloudflare Email Workers or an external service
-    // For now, log the submission and return success
-    console.log("Contact form submission:", {
-      voornaam,
-      achternaam,
-      email,
-      telefoon,
-      bericht,
-      timestamp: new Date().toISOString(),
+    const htmlBody = `
+      <h2>Nieuw contactformulier bericht</h2>
+      <table style="border-collapse:collapse;width:100%;max-width:600px;">
+        <tr><td style="padding:8px;font-weight:bold;">Voornaam</td><td style="padding:8px;">${escapeHtml(voornaam)}</td></tr>
+        <tr><td style="padding:8px;font-weight:bold;">Achternaam</td><td style="padding:8px;">${escapeHtml(achternaam)}</td></tr>
+        <tr><td style="padding:8px;font-weight:bold;">E-mail</td><td style="padding:8px;"><a href="mailto:${escapeHtml(email)}">${escapeHtml(email)}</a></td></tr>
+        <tr><td style="padding:8px;font-weight:bold;">Telefoon</td><td style="padding:8px;">${escapeHtml(telefoon || "-")}</td></tr>
+      </table>
+      <h3 style="margin-top:24px;">Bericht</h3>
+      <p style="white-space:pre-wrap;">${escapeHtml(bericht)}</p>
+      <hr style="margin-top:32px;" />
+      <p style="color:#888;font-size:12px;">Verzonden via het contactformulier op fvbadvocaten.com op ${new Date().toISOString()}</p>
+    `;
+
+    const res = await fetch("https://api.unosend.co/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${context.env.UNOSEND_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: "website@fvbadvocaten.com",
+        to: ["vanbergen@fvbadvocaten.com"],
+        subject: `Contactformulier: ${voornaam} ${achternaam}`,
+        html: htmlBody,
+      }),
     });
+
+    if (!res.ok) {
+      console.error("Unosend error:", res.status, await res.text());
+      return new Response(
+        JSON.stringify({ error: "Er ging iets mis bij het verzenden." }),
+        { status: 502, headers: { "Content-Type": "application/json" } }
+      );
+    }
 
     return new Response(
       JSON.stringify({ success: true, message: "Bericht ontvangen." }),
@@ -37,3 +64,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     );
   }
 };
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/fvbadvocaten/src/app/[locale]/page.tsx
+++ b/fvbadvocaten/src/app/[locale]/page.tsx
@@ -60,9 +60,16 @@ export default async function HomePage({
       <section id="praktijkgebieden" className="bg-steel-100 py-20">
         <Container>
           <SectionHeading>{t.practiceAreas.title}</SectionHeading>
-          <div className="grid gap-10 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
-            {t.practiceAreas.areas.map((area) => (
+          <div className="grid gap-10 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+            {t.practiceAreas.areas.slice(0, -2).map((area) => (
               <PracticeAreaCard key={area.title} {...area} />
+            ))}
+          </div>
+
+          {/* Incasso & Leasing – featured blocks */}
+          <div className="mt-16 grid gap-8 md:grid-cols-2">
+            {t.practiceAreas.areas.slice(-2).map((area) => (
+              <PracticeAreaCard key={area.title} {...area} variant="block" />
             ))}
           </div>
         </Container>

--- a/fvbadvocaten/src/components/Header.tsx
+++ b/fvbadvocaten/src/components/Header.tsx
@@ -43,7 +43,7 @@ export default function Header({ locale }: { locale: Locale }) {
               </Link>
             ))}
             <Link
-              href={`/${locale}/contact/`}
+              href={`/${locale}/#contact`}
               className="bg-accent rounded-md px-4 py-2 text-sm font-medium tracking-wide text-white transition hover:bg-accent/80"
             >
               {t.nav.vacatures}
@@ -74,7 +74,7 @@ export default function Header({ locale }: { locale: Locale }) {
             </Link>
           ))}
           <Link
-            href={`/${locale}/contact/`}
+            href={`/${locale}/#contact`}
             onClick={() => setMobileOpen(false)}
             className="bg-accent mt-2 block rounded-md px-4 py-3 text-center text-sm font-medium tracking-wide text-white transition hover:bg-accent/80"
           >

--- a/fvbadvocaten/src/components/PracticeAreaCard.tsx
+++ b/fvbadvocaten/src/components/PracticeAreaCard.tsx
@@ -32,12 +32,30 @@ export default function PracticeAreaCard({
   title,
   icon,
   description,
+  variant = "icon",
 }: {
   title: string;
   icon: string;
   description: string;
+  variant?: "icon" | "block";
 }) {
   const Icon = iconMap[icon] || Shield;
+
+  if (variant === "block") {
+    return (
+      <div className="bg-navy-800 group flex items-start gap-6 rounded-2xl p-8 shadow-lg">
+        <div className="bg-accent flex h-14 w-14 shrink-0 items-center justify-center rounded-xl">
+          <Icon className="h-7 w-7 text-white" />
+        </div>
+        <div>
+          <h3 className="text-lg font-bold tracking-wide text-white">
+            {title}
+          </h3>
+          <p className="mt-2 leading-relaxed text-white/70">{description}</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="group text-center">

--- a/fvbarbitration/functions/api/contact.ts
+++ b/fvbarbitration/functions/api/contact.ts
@@ -1,24 +1,74 @@
-interface Env {}
+interface Env {
+  UNOSEND_API_KEY: string;
+}
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
   try {
     const body = await context.request.json();
-    const { voornaam, achternaam, email, telefoon, bericht } = body as Record<string, string>;
+    const { voornaam, achternaam, email, telefoon, bericht } = body as Record<
+      string,
+      string
+    >;
 
     if (!voornaam || !achternaam || !email || !bericht) {
-      return new Response(JSON.stringify({ error: "Vul alle verplichte velden in." }), {
-        status: 400, headers: { "Content-Type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({ error: "Vul alle verplichte velden in." }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
     }
 
-    console.log("Contact form submission:", { voornaam, achternaam, email, telefoon, bericht, timestamp: new Date().toISOString() });
+    const htmlBody = `
+      <h2>Nieuw contactformulier bericht</h2>
+      <table style="border-collapse:collapse;width:100%;max-width:600px;">
+        <tr><td style="padding:8px;font-weight:bold;">Voornaam</td><td style="padding:8px;">${escapeHtml(voornaam)}</td></tr>
+        <tr><td style="padding:8px;font-weight:bold;">Achternaam</td><td style="padding:8px;">${escapeHtml(achternaam)}</td></tr>
+        <tr><td style="padding:8px;font-weight:bold;">E-mail</td><td style="padding:8px;"><a href="mailto:${escapeHtml(email)}">${escapeHtml(email)}</a></td></tr>
+        <tr><td style="padding:8px;font-weight:bold;">Telefoon</td><td style="padding:8px;">${escapeHtml(telefoon || "-")}</td></tr>
+      </table>
+      <h3 style="margin-top:24px;">Bericht</h3>
+      <p style="white-space:pre-wrap;">${escapeHtml(bericht)}</p>
+      <hr style="margin-top:32px;" />
+      <p style="color:#888;font-size:12px;">Verzonden via het contactformulier op fvbarbitration.com op ${new Date().toISOString()}</p>
+    `;
 
-    return new Response(JSON.stringify({ success: true, message: "Bericht ontvangen." }), {
-      status: 200, headers: { "Content-Type": "application/json" },
+    const res = await fetch("https://api.unosend.co/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${context.env.UNOSEND_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: "website@fvbarbitration.com",
+        to: ["vanbergen@fvbarbitration.com"],
+        subject: `Contactformulier: ${voornaam} ${achternaam}`,
+        html: htmlBody,
+      }),
     });
+
+    if (!res.ok) {
+      console.error("Unosend error:", res.status, await res.text());
+      return new Response(
+        JSON.stringify({ error: "Er ging iets mis bij het verzenden." }),
+        { status: 502, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, message: "Bericht ontvangen." }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
   } catch {
-    return new Response(JSON.stringify({ error: "Er ging iets mis." }), {
-      status: 500, headers: { "Content-Type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify({ error: "Er ging iets mis." }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
   }
 };
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/fvbmediation/functions/api/contact.ts
+++ b/fvbmediation/functions/api/contact.ts
@@ -1,24 +1,74 @@
-interface Env {}
+interface Env {
+  UNOSEND_API_KEY: string;
+}
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
   try {
     const body = await context.request.json();
-    const { voornaam, achternaam, email, telefoon, bericht } = body as Record<string, string>;
+    const { voornaam, achternaam, email, telefoon, bericht } = body as Record<
+      string,
+      string
+    >;
 
     if (!voornaam || !achternaam || !email || !bericht) {
-      return new Response(JSON.stringify({ error: "Vul alle verplichte velden in." }), {
-        status: 400, headers: { "Content-Type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({ error: "Vul alle verplichte velden in." }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
     }
 
-    console.log("Contact form submission:", { voornaam, achternaam, email, telefoon, bericht, timestamp: new Date().toISOString() });
+    const htmlBody = `
+      <h2>Nieuw contactformulier bericht</h2>
+      <table style="border-collapse:collapse;width:100%;max-width:600px;">
+        <tr><td style="padding:8px;font-weight:bold;">Voornaam</td><td style="padding:8px;">${escapeHtml(voornaam)}</td></tr>
+        <tr><td style="padding:8px;font-weight:bold;">Achternaam</td><td style="padding:8px;">${escapeHtml(achternaam)}</td></tr>
+        <tr><td style="padding:8px;font-weight:bold;">E-mail</td><td style="padding:8px;"><a href="mailto:${escapeHtml(email)}">${escapeHtml(email)}</a></td></tr>
+        <tr><td style="padding:8px;font-weight:bold;">Telefoon</td><td style="padding:8px;">${escapeHtml(telefoon || "-")}</td></tr>
+      </table>
+      <h3 style="margin-top:24px;">Bericht</h3>
+      <p style="white-space:pre-wrap;">${escapeHtml(bericht)}</p>
+      <hr style="margin-top:32px;" />
+      <p style="color:#888;font-size:12px;">Verzonden via het contactformulier op fvbmediation.com op ${new Date().toISOString()}</p>
+    `;
 
-    return new Response(JSON.stringify({ success: true, message: "Bericht ontvangen." }), {
-      status: 200, headers: { "Content-Type": "application/json" },
+    const res = await fetch("https://api.unosend.co/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${context.env.UNOSEND_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: "website@fvbmediation.com",
+        to: ["vanbergen@fvbmediation.com"],
+        subject: `Contactformulier: ${voornaam} ${achternaam}`,
+        html: htmlBody,
+      }),
     });
+
+    if (!res.ok) {
+      console.error("Unosend error:", res.status, await res.text());
+      return new Response(
+        JSON.stringify({ error: "Er ging iets mis bij het verzenden." }),
+        { status: 502, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, message: "Bericht ontvangen." }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
   } catch {
-    return new Response(JSON.stringify({ error: "Er ging iets mis." }), {
-      status: 500, headers: { "Content-Type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify({ error: "Er ging iets mis." }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
   }
 };
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}


### PR DESCRIPTION
## Summary
- Moves incasso & leasingmaatschappijen out of the icon grid into two visually distinct featured block cards below the practice areas on fvbadvocaten
- Points the Vacatures nav button to the homepage contact form (`/#contact`) instead of the `/contact` page
- Replaces `console.log` contact form handlers with Unosend email delivery on all 3 sites (fvbadvocaten, fvbmediation, fvbarbitration), including HTML-formatted emails with XSS escaping

## Setup required
- Set `UNOSEND_API_KEY` secret on each Cloudflare Pages project
- Verify sender domains in Unosend dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)