### PR TITLE
Add SVG favicons with brand colors for all 3 websites

### DIFF
--- a/fvbadvocaten/src/app/icon.svg
+++ b/fvbadvocaten/src/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="4" fill="#1a2632"/>
+  <text x="16" y="22" text-anchor="middle" font-family="Raleway, Arial, Helvetica, sans-serif" font-size="16" font-weight="bold" fill="#ffffff">F<tspan font-size="12" font-style="italic">v</tspan>B</text>
+</svg>

--- a/fvbarbitration/src/app/icon.svg
+++ b/fvbarbitration/src/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="4" fill="#3a5a3a"/>
+  <text x="16" y="22" text-anchor="middle" font-family="Raleway, Arial, Helvetica, sans-serif" font-size="16" font-weight="bold" fill="#ffffff">F<tspan font-size="12" font-style="italic">v</tspan>B</text>
+</svg>

--- a/fvbmediation/src/app/icon.svg
+++ b/fvbmediation/src/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="4" fill="#8b7355"/>
+  <text x="16" y="22" text-anchor="middle" font-family="Raleway, Arial, Helvetica, sans-serif" font-size="16" font-weight="bold" fill="#ffffff">F<tspan font-size="12" font-style="italic">v</tspan>B</text>
+</svg>


### PR DESCRIPTION
## Summary
- Adds SVG favicon (`icon.svg`) to each website: fvbadvocaten (navy), fvbarbitration (green), fvbmediation (tan/gold)
- Each favicon displays the "FvB" monogram in white on the brand color background, using the Raleway font stack
- Next.js will automatically serve `icon.svg` as the tab favicon, taking priority over the existing `favicon.ico`

🤖 Generated with [Claude Code](https://claude.com/claude-code)