### PR TITLE
Add 301 redirects for non-prefixed URLs indexed by Google

### DIFF
--- a/fvbadvocaten/public/_redirects
+++ b/fvbadvocaten/public/_redirects
@@ -1,0 +1,7 @@
+# Redirect non-prefixed URLs to Dutch (/nl/) default language
+/contact/ /nl/contact/ 301
+/contact /nl/contact/ 301
+/privacybeleid/ /nl/privacybeleid/ 301
+/privacybeleid /nl/privacybeleid/ 301
+/algemene-voorwaarden/ /nl/algemene-voorwaarden/ 301
+/algemene-voorwaarden /nl/algemene-voorwaarden/ 301

--- a/fvbadvocaten/public/_redirects
+++ b/fvbadvocaten/public/_redirects
@@ -9,3 +9,9 @@
 /praktijkgebieden /nl/#praktijkgebieden 301
 /wie-is-wie/ /nl/#wie-is-wie 301
 /wie-is-wie /nl/#wie-is-wie 301
+/incasso/ /nl/#praktijkgebieden 301
+/incasso /nl/#praktijkgebieden 301
+/leasingmaatschappij/ /nl/#praktijkgebieden 301
+/leasingmaatschappij /nl/#praktijkgebieden 301
+/vacatures/ /nl/#contact 301
+/vacatures /nl/#contact 301

--- a/fvbadvocaten/public/_redirects
+++ b/fvbadvocaten/public/_redirects
@@ -5,3 +5,7 @@
 /privacybeleid /nl/privacybeleid/ 301
 /algemene-voorwaarden/ /nl/algemene-voorwaarden/ 301
 /algemene-voorwaarden /nl/algemene-voorwaarden/ 301
+/praktijkgebieden/ /nl/#praktijkgebieden 301
+/praktijkgebieden /nl/#praktijkgebieden 301
+/wie-is-wie/ /nl/#wie-is-wie 301
+/wie-is-wie /nl/#wie-is-wie 301

--- a/fvbarbitration/public/_redirects
+++ b/fvbarbitration/public/_redirects
@@ -1,0 +1,5 @@
+# Redirect non-prefixed URLs to Dutch (/nl/) default language
+/privacybeleid/ /nl/privacybeleid/ 301
+/privacybeleid /nl/privacybeleid/ 301
+/algemene-voorwaarden/ /nl/algemene-voorwaarden/ 301
+/algemene-voorwaarden /nl/algemene-voorwaarden/ 301

--- a/fvbmediation/public/_redirects
+++ b/fvbmediation/public/_redirects
@@ -1,0 +1,5 @@
+# Redirect non-prefixed URLs to Dutch (/nl/) default language
+/privacybeleid/ /nl/privacybeleid/ 301
+/privacybeleid /nl/privacybeleid/ 301
+/algemene-voorwaarden/ /nl/algemene-voorwaarden/ 301
+/algemene-voorwaarden /nl/algemene-voorwaarden/ 301


### PR DESCRIPTION
Google has indexed URLs without language prefixes (e.g. `/contact/`, `/privacybeleid/`, `/algemene-voorwaarden/`) that now return 404 since all pages require `/nl/`, `/en/`, or `/fr/` prefixes. This adds Cloudflare Pages `_redirects` files to all three sites (fvbadvocaten, fvbmediation, fvbarbitration) with 301 permanent redirects from non-prefixed URLs to their `/nl/` equivalents. Both with and without trailing slash variants are covered.