### PR TITLE
Add 301 redirect for /leasingsmaatschappij

### DIFF
--- a/fvbadvocaten/public/_redirects
+++ b/fvbadvocaten/public/_redirects
@@ -13,5 +13,7 @@
 /incasso /nl/#praktijkgebieden 301
 /leasingmaatschappij/ /nl/#praktijkgebieden 301
 /leasingmaatschappij /nl/#praktijkgebieden 301
+/leasingsmaatschappij/ /nl/#praktijkgebieden 301
+/leasingsmaatschappij /nl/#praktijkgebieden 301
 /vacatures/ /nl/#contact 301
 /vacatures /nl/#contact 301


### PR DESCRIPTION
The existing redirect only covered `/leasingmaatschappij` (without the "s"), but the URL indexed by Google uses `/leasingsmaatschappij`. This adds the missing variant so it correctly redirects to `/nl/#praktijkgebieden`.