### PR TITLE
Replace Unosend with Resend for contact form emails

### DIFF
--- a/fvbadvocaten/functions/api/contact.ts
+++ b/fvbadvocaten/functions/api/contact.ts
@@ -1,5 +1,5 @@
 interface Env {
-  UNOSEND_API_KEY: string;
+  RESEND_API_KEY: string;
 }
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
@@ -31,22 +31,22 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       <p style="color:#888;font-size:12px;">Verzonden via het contactformulier op fvbadvocaten.com op ${new Date().toISOString()}</p>
     `;
 
-    const res = await fetch("https://api.unosend.co/emails", {
+    const res = await fetch("https://api.resend.com/emails", {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${context.env.UNOSEND_API_KEY}`,
+        Authorization: `Bearer ${context.env.RESEND_API_KEY}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
         from: "website@fvbadvocaten.com",
         to: ["vanbergen@fvbadvocaten.com"],
-        subject: `Contactformulier: ${voornaam} ${achternaam}`,
+        subject: `[fvbadvocaten.com] Contactformulier: ${voornaam} ${achternaam}`,
         html: htmlBody,
       }),
     });
 
     if (!res.ok) {
-      console.error("Unosend error:", res.status, await res.text());
+      console.error("Resend error:", res.status, await res.text());
       return new Response(
         JSON.stringify({ error: "Er ging iets mis bij het verzenden." }),
         { status: 502, headers: { "Content-Type": "application/json" } }

--- a/fvbarbitration/functions/api/contact.ts
+++ b/fvbarbitration/functions/api/contact.ts
@@ -1,5 +1,5 @@
 interface Env {
-  UNOSEND_API_KEY: string;
+  RESEND_API_KEY: string;
 }
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
@@ -31,22 +31,22 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       <p style="color:#888;font-size:12px;">Verzonden via het contactformulier op fvbarbitration.com op ${new Date().toISOString()}</p>
     `;
 
-    const res = await fetch("https://api.unosend.co/emails", {
+    const res = await fetch("https://api.resend.com/emails", {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${context.env.UNOSEND_API_KEY}`,
+        Authorization: `Bearer ${context.env.RESEND_API_KEY}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        from: "website@fvbarbitration.com",
+        from: "website@fvbadvocaten.com",
         to: ["vanbergen@fvbarbitration.com"],
-        subject: `Contactformulier: ${voornaam} ${achternaam}`,
+        subject: `[fvbarbitration.com] Contactformulier: ${voornaam} ${achternaam}`,
         html: htmlBody,
       }),
     });
 
     if (!res.ok) {
-      console.error("Unosend error:", res.status, await res.text());
+      console.error("Resend error:", res.status, await res.text());
       return new Response(
         JSON.stringify({ error: "Er ging iets mis bij het verzenden." }),
         { status: 502, headers: { "Content-Type": "application/json" } }

--- a/fvbmediation/functions/api/contact.ts
+++ b/fvbmediation/functions/api/contact.ts
@@ -1,5 +1,5 @@
 interface Env {
-  UNOSEND_API_KEY: string;
+  RESEND_API_KEY: string;
 }
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
@@ -31,22 +31,22 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       <p style="color:#888;font-size:12px;">Verzonden via het contactformulier op fvbmediation.com op ${new Date().toISOString()}</p>
     `;
 
-    const res = await fetch("https://api.unosend.co/emails", {
+    const res = await fetch("https://api.resend.com/emails", {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${context.env.UNOSEND_API_KEY}`,
+        Authorization: `Bearer ${context.env.RESEND_API_KEY}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        from: "website@fvbmediation.com",
+        from: "website@fvbadvocaten.com",
         to: ["vanbergen@fvbmediation.com"],
-        subject: `Contactformulier: ${voornaam} ${achternaam}`,
+        subject: `[fvbmediation.com] Contactformulier: ${voornaam} ${achternaam}`,
         html: htmlBody,
       }),
     });
 
     if (!res.ok) {
-      console.error("Unosend error:", res.status, await res.text());
+      console.error("Resend error:", res.status, await res.text());
       return new Response(
         JSON.stringify({ error: "Er ging iets mis bij het verzenden." }),
         { status: 502, headers: { "Content-Type": "application/json" } }


### PR DESCRIPTION
## Summary
- Switches all three websites (fvbmediation, fvbarbitration, fvbadvocaten) from Unosend to the Resend API for sending contact form emails.
- All emails are now sent from the `fvbadvocaten.com` domain (`website@fvbadvocaten.com`).
- Subject lines now include the originating website name, e.g. `[fvbmediation.com] Contactformulier: ...`.
- Environment variable changed from `UNOSEND_API_KEY` to `RESEND_API_KEY`.

## Action required
- Add `RESEND_API_KEY` to Cloudflare Pages environment variables for all three projects.
- Remove the old `UNOSEND_API_KEY` secret.
- Verify `fvbadvocaten.com` sending domain in Resend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)