### PR TITLE
Surface Resend error in contact form response

### DIFF
--- a/fvbarbitration/functions/api/contact.ts
+++ b/fvbarbitration/functions/api/contact.ts
@@ -46,9 +46,9 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     });
 
     if (!res.ok) {
-      console.error("Resend error:", res.status, await res.text());
+      const resendBody = await res.text();
       return new Response(
-        JSON.stringify({ error: "Er ging iets mis bij het verzenden." }),
+        JSON.stringify({ error: resendBody }),
         { status: 502, headers: { "Content-Type": "application/json" } }
       );
     }

--- a/fvbmediation/functions/api/contact.ts
+++ b/fvbmediation/functions/api/contact.ts
@@ -46,9 +46,9 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     });
 
     if (!res.ok) {
-      console.error("Resend error:", res.status, await res.text());
+      const resendBody = await res.text();
       return new Response(
-        JSON.stringify({ error: "Er ging iets mis bij het verzenden." }),
+        JSON.stringify({ error: resendBody }),
         { status: 502, headers: { "Content-Type": "application/json" } }
       );
     }


### PR DESCRIPTION
## Summary
- Surfaces the raw Resend API error in the 502 response body for fvbmediation and fvbarbitration contact forms, matching the change already deployed on fvbadvocaten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)