### PR TITLE
Add vacatures section with recruitment text on home page

### DIFF
--- a/fvbadvocaten/src/app/[locale]/page.tsx
+++ b/fvbadvocaten/src/app/[locale]/page.tsx
@@ -228,10 +228,22 @@ export default async function HomePage({
         />
       </section>
 
-      {/* Contact section on home */}
-      <section id="contact" className="py-20">
+      {/* Vacatures */}
+      <section id="contact" className="bg-navy-800 py-20 text-white">
         <Container>
-          <SectionHeading>{t.contact.title}</SectionHeading>
+          <SectionHeading light>{t.vacatures.title}</SectionHeading>
+          <div className="mx-auto max-w-3xl text-center">
+            <p className="text-lg leading-relaxed text-white/80">
+              {t.vacatures.description}
+            </p>
+          </div>
+        </Container>
+      </section>
+
+      {/* Contact */}
+      <section className="py-20">
+        <Container>
+          <SectionHeading>{t.vacatures.cta}</SectionHeading>
           <div className="mx-auto max-w-2xl">
             <div className="mb-8 text-center text-gray-600">
               <p>

--- a/fvbadvocaten/src/lib/i18n.ts
+++ b/fvbadvocaten/src/lib/i18n.ts
@@ -148,6 +148,11 @@ function nl() {
         bio: "Kaylee staat het team op administratief en organisatorisch vlak bij. Door haar accuratesse en stiptheid is zij een absolute meerwaarde voor het kantoor.",
       },
     },
+    vacatures: {
+      title: "Vacatures",
+      description: "ADVOCATENKANTOOR FILIP van BERGEN is omwille van de expansie van het kantoor steeds op zoek naar hoog gekwalificeerde en gemotiveerde medewerkers, die bereid zijn voor de klanten van het kantoor het grootst mogelijke engagement aan te gaan bij het adviseren en het verlenen van gerechtelijke bijstand.",
+      cta: "Solliciteren?",
+    },
     contact: {
       title: "Contact",
       sendMessage: "Stuur ons een bericht",
@@ -332,6 +337,11 @@ function en() {
         bio: "Kaylee supports the team in administrative and organisational matters. Through her accuracy and punctuality she is an absolute asset to the firm.",
       },
     },
+    vacatures: {
+      title: "Careers",
+      description: "As a result of the firm's expansion, ADVOCATENKANTOOR FILIP van BERGEN is constantly on the look-out for highly qualified and motivated employees, who are prepared to go the extra mile when providing advice and legal assistance.",
+      cta: "Apply?",
+    },
     contact: {
       title: "Contact",
       sendMessage: "Send us a message",
@@ -515,6 +525,11 @@ function fr() {
         role: "Administration & Office Manager",
         bio: "Kaylee soutient l'équipe sur le plan administratif et organisationnel. Par sa précision et sa ponctualité, elle est un atout absolu pour le cabinet.",
       },
+    },
+    vacatures: {
+      title: "Offres d'emploi",
+      description: "En raison de son expansion, le CABINET D'AVOCATS FILIP van BERGEN est constamment à la recherche de collaborateurs hautement qualifiés et motivés, prêts à s'engager à fond pour les clients du cabinet en leur apportant conseils et assistance juridique.",
+      cta: "Sollicitez?",
     },
     contact: {
       title: "Contact",


### PR DESCRIPTION
## Summary
- Adds a new "Vacatures" section on the home page above the contact form, with a dark background and the firm's recruitment message
- The contact form is now headed with "Solliciteren?" / "Apply?" / "Sollicitez?" as a call to action
- Translations added for all three languages (NL, EN, FR) in i18n.ts

## Test plan
- [ ] Verify the vacatures text displays correctly on the home page in all three languages
- [ ] Verify the "Vacatures" nav button scrolls to the new section
- [ ] Verify the contact form still works correctly below the recruitment text

🤖 Generated with [Claude Code](https://claude.com/claude-code)