### PR TITLE
Add bank account details to footer across all three sites

### DIFF
--- a/fvbadvocaten/src/components/Footer.tsx
+++ b/fvbadvocaten/src/components/Footer.tsx
@@ -8,7 +8,7 @@ export default function Footer({ locale }: { locale: Locale }) {
   return (
     <footer className="bg-navy-900 text-white/70">
       <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
-        <div className="grid gap-8 md:grid-cols-3">
+        <div className="grid gap-8 md:grid-cols-4">
           <div>
             <h3 className="mb-3 text-lg font-bold text-white">{SITE_NAME}</h3>
             <p className="text-sm leading-relaxed">
@@ -41,6 +41,26 @@ export default function Footer({ locale }: { locale: Locale }) {
               >
                 {CONTACT.email}
               </a>
+            </p>
+          </div>
+
+          <div>
+            <h3 className="mb-3 text-lg font-bold text-white">
+              {t.footer.accounts}
+            </h3>
+            <p className="text-sm leading-relaxed">
+              {t.footer.officeAccount}:
+              <br />
+              IBAN BE08 6451 0409 8213
+              <br />
+              (Bank J. Van Breda &amp; C°)
+              <br />
+              <br />
+              {t.footer.thirdPartyAccount}:
+              <br />
+              IBAN BE43 6304 0052 6601
+              <br />
+              (ING)
             </p>
           </div>
 

--- a/fvbadvocaten/src/lib/i18n.ts
+++ b/fvbadvocaten/src/lib/i18n.ts
@@ -178,6 +178,9 @@ function nl() {
       terms: "Algemene Voorwaarden",
       privacy: "Privacybeleid",
       rights: "Alle rechten voorbehouden.",
+      accounts: "Rekeningen",
+      officeAccount: "Kantoorrekening",
+      thirdPartyAccount: "Derdenrekening",
     },
     seo: {
       home: {
@@ -367,6 +370,9 @@ function en() {
       terms: "Terms & Conditions",
       privacy: "Privacy Policy",
       rights: "All rights reserved.",
+      accounts: "Bank Accounts",
+      officeAccount: "Office Account",
+      thirdPartyAccount: "Third-Party Account",
     },
     seo: {
       home: {
@@ -556,6 +562,9 @@ function fr() {
       terms: "Conditions générales",
       privacy: "Politique de confidentialité",
       rights: "Tous droits réservés.",
+      accounts: "Comptes bancaires",
+      officeAccount: "Compte du cabinet",
+      thirdPartyAccount: "Compte de tiers",
     },
     seo: {
       home: {

--- a/fvbarbitration/src/components/Footer.tsx
+++ b/fvbarbitration/src/components/Footer.tsx
@@ -8,7 +8,7 @@ export default function Footer({ locale }: { locale: Locale }) {
   return (
     <footer className="bg-sage-900 text-white/70">
       <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
-        <div className="grid gap-8 md:grid-cols-3">
+        <div className="grid gap-8 md:grid-cols-4">
           <div>
             <h3 className="mb-3 text-lg font-bold text-white">{SITE_NAME}</h3>
             <p className="text-sm leading-relaxed">
@@ -31,6 +31,25 @@ export default function Footer({ locale }: { locale: Locale }) {
               <a href={`mailto:${CONTACT.email}`} className="hover:text-white">
                 {CONTACT.email}
               </a>
+            </p>
+          </div>
+          <div>
+            <h3 className="mb-3 text-lg font-bold text-white">
+              {t.footer.accounts}
+            </h3>
+            <p className="text-sm leading-relaxed">
+              {t.footer.officeAccount}:
+              <br />
+              IBAN BE08 6451 0409 8213
+              <br />
+              (Bank J. Van Breda &amp; C°)
+              <br />
+              <br />
+              {t.footer.thirdPartyAccount}:
+              <br />
+              IBAN BE43 6304 0052 6601
+              <br />
+              (ING)
             </p>
           </div>
           <div>

--- a/fvbarbitration/src/lib/i18n.ts
+++ b/fvbarbitration/src/lib/i18n.ts
@@ -64,6 +64,9 @@ function nl() {
       terms: "Algemene Voorwaarden",
       privacy: "Privacybeleid",
       rights: "Alle rechten voorbehouden.",
+      accounts: "Rekeningen",
+      officeAccount: "Kantoorrekening",
+      thirdPartyAccount: "Derdenrekening",
     },
     seo: {
       home: {
@@ -130,6 +133,9 @@ function en() {
       terms: "Terms & Conditions",
       privacy: "Privacy Policy",
       rights: "All rights reserved.",
+      accounts: "Bank Accounts",
+      officeAccount: "Office Account",
+      thirdPartyAccount: "Third-Party Account",
     },
     seo: {
       home: {
@@ -196,6 +202,9 @@ function fr() {
       terms: "Conditions générales",
       privacy: "Politique de confidentialité",
       rights: "Tous droits réservés.",
+      accounts: "Comptes bancaires",
+      officeAccount: "Compte du cabinet",
+      thirdPartyAccount: "Compte de tiers",
     },
     seo: {
       home: {

--- a/fvbmediation/src/components/Footer.tsx
+++ b/fvbmediation/src/components/Footer.tsx
@@ -8,7 +8,7 @@ export default function Footer({ locale }: { locale: Locale }) {
   return (
     <footer className="bg-tan-900 text-white/70">
       <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
-        <div className="grid gap-8 md:grid-cols-3">
+        <div className="grid gap-8 md:grid-cols-4">
           <div>
             <h3 className="mb-3 text-lg font-bold text-white">{SITE_NAME}</h3>
             <p className="text-sm leading-relaxed">
@@ -31,6 +31,25 @@ export default function Footer({ locale }: { locale: Locale }) {
               <a href={`mailto:${CONTACT.email}`} className="hover:text-white">
                 {CONTACT.email}
               </a>
+            </p>
+          </div>
+          <div>
+            <h3 className="mb-3 text-lg font-bold text-white">
+              {t.footer.accounts}
+            </h3>
+            <p className="text-sm leading-relaxed">
+              {t.footer.officeAccount}:
+              <br />
+              IBAN BE08 6451 0409 8213
+              <br />
+              (Bank J. Van Breda &amp; C°)
+              <br />
+              <br />
+              {t.footer.thirdPartyAccount}:
+              <br />
+              IBAN BE43 6304 0052 6601
+              <br />
+              (ING)
             </p>
           </div>
           <div>

--- a/fvbmediation/src/lib/i18n.ts
+++ b/fvbmediation/src/lib/i18n.ts
@@ -65,6 +65,9 @@ function nl() {
       terms: "Algemene Voorwaarden",
       privacy: "Privacybeleid",
       rights: "Alle rechten voorbehouden.",
+      accounts: "Rekeningen",
+      officeAccount: "Kantoorrekening",
+      thirdPartyAccount: "Derdenrekening",
     },
     seo: {
       home: {
@@ -132,6 +135,9 @@ function en() {
       terms: "Terms & Conditions",
       privacy: "Privacy Policy",
       rights: "All rights reserved.",
+      accounts: "Bank Accounts",
+      officeAccount: "Office Account",
+      thirdPartyAccount: "Third-Party Account",
     },
     seo: {
       home: {
@@ -199,6 +205,9 @@ function fr() {
       terms: "Conditions générales",
       privacy: "Politique de confidentialité",
       rights: "Tous droits réservés.",
+      accounts: "Comptes bancaires",
+      officeAccount: "Compte du cabinet",
+      thirdPartyAccount: "Compte de tiers",
     },
     seo: {
       home: {


### PR DESCRIPTION
Adds a "Rekeningen" (Bank Accounts) section to the footer of fvbadvocaten, fvbmediation, and fvbarbitration. Displays the Kantoorrekening (IBAN BE08 6451 0409 8213, Bank J. Van Breda & C°) and Derdenrekening (IBAN BE43 6304 0052 6601, ING). The footer grid is expanded from 3 to 4 columns. All labels are translated in NL, EN, and FR via each site's i18n dictionary.