### PR TITLE
#21 - Fix blog post deploy triggers (DELETE missing, wrong fallback repo, inline duplication)

### DIFF
--- a/admin/src/app/(authenticated)/layout.tsx
+++ b/admin/src/app/(authenticated)/layout.tsx
@@ -1,5 +1,6 @@
 import { headers } from "next/headers";
 import Sidebar from "@/components/Sidebar";
+import { ToastProvider } from "@/components/ToastProvider";
 
 export default async function AuthenticatedLayout({
   children,
@@ -10,9 +11,11 @@ export default async function AuthenticatedLayout({
   const email = headersList.get("cf-access-authenticated-user-email") || "admin";
 
   return (
-    <div className="flex min-h-screen">
-      <Sidebar email={email} />
-      <main className="flex-1 p-8">{children}</main>
-    </div>
+    <ToastProvider>
+      <div className="flex min-h-screen">
+        <Sidebar email={email} />
+        <main className="flex-1 p-8">{children}</main>
+      </div>
+    </ToastProvider>
   );
 }

--- a/admin/src/app/(authenticated)/posts/page.tsx
+++ b/admin/src/app/(authenticated)/posts/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Plus, Edit, Trash2, Eye, EyeOff, BarChart3 } from "lucide-react";
+import { useToast } from "@/components/ToastProvider";
 
 interface PostRow {
   id: string;
@@ -18,6 +19,7 @@ interface PostRow {
 export default function PostsPage() {
   const [posts, setPosts] = useState<PostRow[]>([]);
   const [loading, setLoading] = useState(true);
+  const toast = useToast();
 
   useEffect(() => {
     fetch("/api/posts")
@@ -31,9 +33,16 @@ export default function PostsPage() {
 
   async function handleDelete(id: string) {
     if (!confirm("Are you sure you want to delete this post?")) return;
-    const res = await fetch(`/api/posts/${id}`, { method: "DELETE" });
-    if (res.ok) {
-      setPosts((prev) => prev.filter((p) => p.id !== id));
+    try {
+      const res = await fetch(`/api/posts/${id}`, { method: "DELETE" });
+      if (res.ok) {
+        setPosts((prev) => prev.filter((p) => p.id !== id));
+        toast.success("Post deleted successfully");
+      } else {
+        toast.error("Failed to delete post");
+      }
+    } catch {
+      toast.error("Failed to delete post");
     }
   }
 

--- a/admin/src/app/(authenticated)/settings/page.tsx
+++ b/admin/src/app/(authenticated)/settings/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Settings, Eye, EyeOff } from "lucide-react";
+import { Eye, EyeOff, RefreshCw, Settings } from "lucide-react";
+import { useToast } from "@/components/ToastProvider";
 
 interface SiteSetting {
   site: string;
@@ -14,10 +15,14 @@ const SITE_LABELS: Record<string, string> = {
   fvbarbitration: "FVB Arbitrage",
 };
 
+const ALL_SITES = ["fvbadvocaten", "fvbmediation", "fvbarbitration"];
+
 export default function SettingsPage() {
   const [settings, setSettings] = useState<SiteSetting[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState<string | null>(null);
+  const [deploying, setDeploying] = useState(false);
+  const toast = useToast();
 
   useEffect(() => {
     fetch("/api/settings")
@@ -43,11 +48,34 @@ export default function SettingsPage() {
             s.site === site ? { ...s, blog_menu_visible: !current } : s
           )
         );
+        toast.success(`Blog menu ${!current ? "shown" : "hidden"} on ${SITE_LABELS[site] ?? site}`);
+      } else {
+        toast.error("Failed to update setting");
       }
     } catch {
-      // ignore
+      toast.error("Failed to update setting");
     } finally {
       setSaving(null);
+    }
+  }
+
+  async function deployAll() {
+    setDeploying(true);
+    try {
+      const res = await fetch("/api/v1/deploy", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sites: ALL_SITES }),
+      });
+      if (res.ok) {
+        toast.success("Deploy triggered for all 3 websites");
+      } else {
+        toast.error("Failed to trigger deploy");
+      }
+    } catch {
+      toast.error("Failed to trigger deploy");
+    } finally {
+      setDeploying(false);
     }
   }
 
@@ -58,52 +86,69 @@ export default function SettingsPage() {
         <h1 className="text-2xl font-bold font-heading text-navy-900">Settings</h1>
       </div>
 
-      <div className="bg-white rounded-xl shadow-sm border border-steel-200 p-6">
-        <h2 className="text-lg font-semibold text-navy-900 mb-2">Blog Menu Visibility</h2>
-        <p className="text-sm text-navy-500 mb-6">
-          Control whether the Blog menu item is visible on each website. Hide it until you have blog posts ready to show.
-        </p>
+      <div className="space-y-6">
+        <div className="bg-white rounded-xl shadow-sm border border-steel-200 p-6">
+          <h2 className="text-lg font-semibold text-navy-900 mb-2">Blog Menu Visibility</h2>
+          <p className="text-sm text-navy-500 mb-6">
+            Control whether the Blog menu item is visible on each website. Hide it until you have blog posts ready to show.
+          </p>
 
-        {loading ? (
-          <p className="text-sm text-navy-500">Loading...</p>
-        ) : (
-          <div className="space-y-4">
-            {settings.map((setting) => (
-              <div
-                key={setting.site}
-                className="flex items-center justify-between rounded-lg border border-steel-200 p-4"
-              >
-                <div>
-                  <p className="text-sm font-medium text-navy-900">
-                    {SITE_LABELS[setting.site] || setting.site}
-                  </p>
-                  <p className="text-xs text-navy-500">{setting.site}</p>
-                </div>
-                <button
-                  onClick={() => toggleBlogMenu(setting.site, setting.blog_menu_visible)}
-                  disabled={saving === setting.site}
-                  className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                    setting.blog_menu_visible
-                      ? "bg-green-100 text-green-700 hover:bg-green-200"
-                      : "bg-steel-100 text-navy-500 hover:bg-steel-200"
-                  }`}
+          {loading ? (
+            <p className="text-sm text-navy-500">Loading...</p>
+          ) : (
+            <div className="space-y-4">
+              {settings.map((setting) => (
+                <div
+                  key={setting.site}
+                  className="flex items-center justify-between rounded-lg border border-steel-200 p-4"
                 >
-                  {setting.blog_menu_visible ? (
-                    <>
-                      <Eye className="w-4 h-4" />
-                      Visible
-                    </>
-                  ) : (
-                    <>
-                      <EyeOff className="w-4 h-4" />
-                      Hidden
-                    </>
-                  )}
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
+                  <div>
+                    <p className="text-sm font-medium text-navy-900">
+                      {SITE_LABELS[setting.site] || setting.site}
+                    </p>
+                    <p className="text-xs text-navy-500">{setting.site}</p>
+                  </div>
+                  <button
+                    onClick={() => toggleBlogMenu(setting.site, setting.blog_menu_visible)}
+                    disabled={saving === setting.site}
+                    className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                      setting.blog_menu_visible
+                        ? "bg-green-100 text-green-700 hover:bg-green-200"
+                        : "bg-steel-100 text-navy-500 hover:bg-steel-200"
+                    }`}
+                  >
+                    {setting.blog_menu_visible ? (
+                      <>
+                        <Eye className="w-4 h-4" />
+                        Visible
+                      </>
+                    ) : (
+                      <>
+                        <EyeOff className="w-4 h-4" />
+                        Hidden
+                      </>
+                    )}
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="bg-white rounded-xl shadow-sm border border-steel-200 p-6">
+          <h2 className="text-lg font-semibold text-navy-900 mb-2">Manual Deploy</h2>
+          <p className="text-sm text-navy-500 mb-6">
+            Trigger a rebuild of all three websites. Use this after making changes that require a fresh deploy.
+          </p>
+          <button
+            onClick={deployAll}
+            disabled={deploying}
+            className="flex items-center gap-2 bg-accent text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-accent/90 transition-colors disabled:opacity-50"
+          >
+            <RefreshCw className={`w-4 h-4 ${deploying ? "animate-spin" : ""}`} />
+            {deploying ? "Deploying..." : "Deploy all websites"}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/admin/src/app/api/posts/[id]/route.ts
+++ b/admin/src/app/api/posts/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { triggerDeploy } from "@/lib/deploy";
 
 export async function GET(
   _request: NextRequest,
@@ -160,41 +161,11 @@ export async function PUT(
     // Trigger deploy if publishing or unpublishing
     let deployStatus: string | null = null;
     if (publish || wasPublished) {
-      const githubToken = env.GITHUB_TOKEN;
-      const githubRepo = env.GITHUB_REPO;
-      if (!githubToken) {
-        deployStatus = "error: GITHUB_TOKEN not set";
-      } else if (!githubRepo) {
-        deployStatus = "error: GITHUB_REPO not set";
-      } else {
-        try {
-          const ghRes = await fetch(`https://api.github.com/repos/${githubRepo}/dispatches`, {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${githubToken}`,
-              Accept: "application/vnd.github+json",
-              "Content-Type": "application/json",
-              "User-Agent": "fvb-admin",
-            },
-            body: JSON.stringify({
-              event_type: "blog_publish",
-              client_payload: {
-                sites: sites.join(","),
-                deploy_advocaten: sites.includes("fvbadvocaten") ? "true" : "false",
-                deploy_mediation: sites.includes("fvbmediation") ? "true" : "false",
-                deploy_arbitration: sites.includes("fvbarbitration") ? "true" : "false",
-              },
-            }),
-          });
-          if (ghRes.ok) {
-            deployStatus = "triggered";
-          } else {
-            const text = await ghRes.text();
-            deployStatus = `error: ${ghRes.status} ${text}`;
-          }
-        } catch (deployErr) {
-          deployStatus = `error: ${deployErr}`;
-        }
+      try {
+        await triggerDeploy(env, sites);
+        deployStatus = "triggered";
+      } catch (err) {
+        deployStatus = `error: ${err}`;
       }
     }
 
@@ -215,12 +186,28 @@ export async function DELETE(
     const { env } = await getCloudflareContext({ async: true });
     const db = env.DB;
 
+    const post = await db
+      .prepare("SELECT status FROM posts WHERE id = ?1")
+      .bind(id)
+      .first<{ status: string }>();
+
+    const sitesResult = await db
+      .prepare("SELECT site FROM post_sites WHERE post_id = ?1")
+      .bind(id)
+      .all<{ site: string }>();
+
+    const sites = sitesResult.results.map((r) => r.site);
+
     // Cascading deletes handle translations, sites, categories, tags
     await db.prepare("DELETE FROM post_translations WHERE post_id = ?1").bind(id).run();
     await db.prepare("DELETE FROM post_sites WHERE post_id = ?1").bind(id).run();
     await db.prepare("DELETE FROM post_categories WHERE post_id = ?1").bind(id).run();
     await db.prepare("DELETE FROM post_tags WHERE post_id = ?1").bind(id).run();
     await db.prepare("DELETE FROM posts WHERE id = ?1").bind(id).run();
+
+    if (post?.status === "published" && sites.length > 0) {
+      await triggerDeploy(env, sites);
+    }
 
     return NextResponse.json({ success: true });
   } catch (e) {

--- a/admin/src/app/api/posts/route.ts
+++ b/admin/src/app/api/posts/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { headers } from "next/headers";
+import { triggerDeploy } from "@/lib/deploy";
 
 export async function GET() {
   try {
@@ -114,31 +115,7 @@ export async function POST(request: NextRequest) {
 
     // Trigger deploy if publishing
     if (publish) {
-      try {
-        const githubToken = env.GITHUB_TOKEN;
-        const githubRepo = env.GITHUB_REPO || "filipvanbergen/karachi";
-        if (githubToken) {
-          await fetch(`https://api.github.com/repos/${githubRepo}/dispatches`, {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${githubToken}`,
-              Accept: "application/vnd.github.v3+json",
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              event_type: "blog_publish",
-              client_payload: {
-                sites: sites.join(","),
-                deploy_advocaten: sites.includes("fvbadvocaten") ? "true" : "false",
-                deploy_mediation: sites.includes("fvbmediation") ? "true" : "false",
-                deploy_arbitration: sites.includes("fvbarbitration") ? "true" : "false",
-              },
-            }),
-          });
-        }
-      } catch (deployErr) {
-        console.error("Deploy trigger failed:", deployErr);
-      }
+      await triggerDeploy(env, sites);
     }
 
     return NextResponse.json({ id, slug, status });

--- a/admin/src/app/api/v1/deploy/route.ts
+++ b/admin/src/app/api/v1/deploy/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { triggerDeploy } from "@/lib/deploy";
 
 export async function POST(request: NextRequest) {
   try {
@@ -14,45 +15,8 @@ export async function POST(request: NextRequest) {
     }
 
     const { env } = await getCloudflareContext({ async: true });
-    const githubToken = env.GITHUB_TOKEN;
-    const githubRepo = env.GITHUB_REPO || "filipvanbergen/karachi";
 
-    if (!githubToken) {
-      return NextResponse.json(
-        { error: "GitHub token not configured" },
-        { status: 500 }
-      );
-    }
-
-    const res = await fetch(
-      `https://api.github.com/repos/${githubRepo}/dispatches`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${githubToken}`,
-          Accept: "application/vnd.github.v3+json",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          event_type: "blog_publish",
-          client_payload: {
-            sites: sites.join(","),
-            deploy_advocaten: sites.includes("fvbadvocaten") ? "true" : "false",
-            deploy_mediation: sites.includes("fvbmediation") ? "true" : "false",
-            deploy_arbitration: sites.includes("fvbarbitration") ? "true" : "false",
-          },
-        }),
-      }
-    );
-
-    if (!res.ok) {
-      const text = await res.text();
-      console.error("GitHub API error:", res.status, text);
-      return NextResponse.json(
-        { error: "Failed to trigger deploy" },
-        { status: 502 }
-      );
-    }
+    await triggerDeploy(env, sites);
 
     return NextResponse.json({ success: true, sites });
   } catch {

--- a/admin/src/components/PostForm.tsx
+++ b/admin/src/components/PostForm.tsx
@@ -6,6 +6,7 @@ import dynamic from "next/dynamic";
 import { Save, Eye, EyeOff, Globe, Send, Upload, X } from "lucide-react";
 import { LOCALES, SITES, type Locale } from "@/lib/types";
 import SocialShareButtons from "./SocialShareButtons";
+import { useToast } from "./ToastProvider";
 
 // Dynamic import to avoid SSR issues with TipTap
 const Editor = dynamic(() => import("./Editor"), { ssr: false });
@@ -57,8 +58,8 @@ export default function PostForm({ postId, initialData }: PostFormProps) {
   const [saving, setSaving] = useState(false);
   const [publishing, setPublishing] = useState(false);
   const [uploading, setUploading] = useState(false);
-  const [error, setError] = useState("");
   const [showShareButtons, setShowShareButtons] = useState(false);
+  const toast = useToast();
 
   function updateTranslation(
     locale: Locale,
@@ -92,7 +93,6 @@ export default function PostForm({ postId, initialData }: PostFormProps) {
   }
 
   async function handleSave(publish: boolean) {
-    setError("");
     publish ? setPublishing(true) : setSaving(true);
 
     try {
@@ -116,19 +116,21 @@ export default function PostForm({ postId, initialData }: PostFormProps) {
       const data = await res.json();
 
       if (!res.ok) {
-        setError(data.error || "Failed to save");
+        toast.error(data.error || "Failed to save");
         return;
       }
 
       if (publish) {
         setIsPublished(true);
         setShowShareButtons(true);
+        toast.success(postId ? "Post updated successfully" : "Post published successfully");
       } else {
+        toast.success(isPublished ? "Post unpublished" : "Draft saved");
         setIsPublished(false);
         router.push("/posts");
       }
     } catch {
-      setError("An error occurred");
+      toast.error("An error occurred");
     } finally {
       setSaving(false);
       setPublishing(false);
@@ -142,12 +144,6 @@ export default function PostForm({ postId, initialData }: PostFormProps) {
 
   return (
     <div className="space-y-6">
-      {error && (
-        <div className="bg-red-50 text-red-700 px-4 py-3 rounded-lg text-sm">
-          {error}
-        </div>
-      )}
-
       {showShareButtons && (
         <div className="bg-green-50 border border-green-200 rounded-xl p-6">
           <h3 className="text-lg font-semibold text-green-800 mb-2">
@@ -310,7 +306,6 @@ export default function PostForm({ postId, initialData }: PostFormProps) {
                     const file = e.target.files?.[0];
                     if (!file) return;
                     setUploading(true);
-                    setError("");
                     try {
                       const formData = new FormData();
                       formData.append("file", file);
@@ -320,13 +315,13 @@ export default function PostForm({ postId, initialData }: PostFormProps) {
                       });
                       const data = await res.json();
                       if (!res.ok) {
-                        setError(data.error || "Upload failed");
+                        toast.error(data.error || "Upload failed");
                       } else {
                         setFeaturedImage(data.url);
                         setFeaturedImagePreview(data.previewUrl || data.url);
                       }
                     } catch {
-                      setError("Upload failed");
+                      toast.error("Upload failed");
                     } finally {
                       setUploading(false);
                       e.target.value = "";

--- a/admin/src/components/ToastProvider.tsx
+++ b/admin/src/components/ToastProvider.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { createContext, useCallback, useContext, useRef, useState } from "react";
+import { AlertCircle, CheckCircle, X } from "lucide-react";
+
+type ToastType = "success" | "error";
+
+interface ToastItem {
+  id: number;
+  type: ToastType;
+  message: string;
+}
+
+const ToastContext = createContext<(type: ToastType, message: string) => void>(() => {});
+
+export function useToast() {
+  const add = useContext(ToastContext);
+  return {
+    success: (message: string) => add("success", message),
+    error: (message: string) => add("error", message),
+  };
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const counter = useRef(0);
+
+  const add = useCallback((type: ToastType, message: string) => {
+    const id = ++counter.current;
+    setToasts((prev) => [...prev, { id, type, message }]);
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 4000);
+  }, []);
+
+  const dismiss = (id: number) => setToasts((prev) => prev.filter((t) => t.id !== id));
+
+  return (
+    <ToastContext.Provider value={add}>
+      {children}
+      <div className="fixed top-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className={`flex items-start gap-3 px-4 py-3 rounded-lg shadow-lg border text-sm font-medium max-w-sm pointer-events-auto ${
+              t.type === "success"
+                ? "bg-green-50 border-green-200 text-green-800"
+                : "bg-red-50 border-red-200 text-red-800"
+            }`}
+          >
+            {t.type === "success" ? (
+              <CheckCircle className="w-4 h-4 flex-shrink-0 text-green-600 mt-0.5" />
+            ) : (
+              <AlertCircle className="w-4 h-4 flex-shrink-0 text-red-600 mt-0.5" />
+            )}
+            <span className="flex-1">{t.message}</span>
+            <button
+              onClick={() => dismiss(t.id)}
+              className="ml-1 opacity-60 hover:opacity-100 transition-opacity"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}


### PR DESCRIPTION
## Purpose

This bugfix consolidates blog post deploy trigger logic across the admin API and adds user-facing feedback via toasts. Three server-side bugs are fixed — DELETE never triggering a deploy, wrong fallback repo being used, and inline dispatch code diverging from the shared helper — plus a toast notification system and a manual deploy button are added to improve the admin UX.

## Key Changes

- **DELETE handler now triggers a deploy** when a published post is deleted, so sites rebuild and the post is no longer visible
- **Wrong fallback repo fixed** — `posts/route.ts` (POST) and `v1/deploy/route.ts` no longer fall back to `filipvanbergen/karachi`; all routes now use the shared `triggerDeploy` helper with the correct fallback (`jordandevogelaere/filipvanbergen`)
- **Inline fetch blocks removed** from `posts/route.ts` (POST) and `posts/[id]/route.ts` (PUT); all deploy calls now go through `lib/deploy.ts`
- **Toast notification system** added (`ToastProvider` context + `useToast` hook) — success and error toasts appear top-right, auto-dismiss after 4 seconds, and persist across client-side navigation
- **PostForm inline error div replaced** with `toast.error`; save/publish/unpublish/upload errors and successes all surface as toasts
- **Settings page: Manual Deploy section** added with a "Deploy all websites" button that triggers all three sites via `POST /api/v1/deploy`

## Checks

- [ ] Code compiles without errors
- [ ] Changes have been tested locally
- [ ] No console.log or debug statements left behind
- [ ] Types are properly defined

## Task

[#21](https://github.com/jordandevogelaere/filipvanbergen/issues/21)