### PR TITLE
#24 - Fix: trigger site rebuilds when removing sites from a post or deleting a published post

### DIFF
--- a/admin/src/app/api/posts/[id]/route.ts
+++ b/admin/src/app/api/posts/[id]/route.ts
@@ -149,6 +149,13 @@ export async function PUT(
       }
     }
 
+    // Read current site assignments before replacing them
+    const oldSitesResult = await db
+      .prepare("SELECT site FROM post_sites WHERE post_id = ?1")
+      .bind(id)
+      .all<{ site: string }>();
+    const oldSites = oldSitesResult.results.map((r) => r.site);
+
     // Replace site assignments
     await db.prepare("DELETE FROM post_sites WHERE post_id = ?1").bind(id).run();
     for (const site of sites) {
@@ -158,11 +165,13 @@ export async function PUT(
         .run();
     }
 
-    // Trigger deploy if publishing or unpublishing
+    // Trigger deploy if publishing or unpublishing; deploy to union of old + new sites
+    // so removed sites also get rebuilt and no longer show the post
     let deployStatus: string | null = null;
     if (publish || wasPublished) {
+      const sitesToDeploy = [...new Set([...oldSites, ...sites])];
       try {
-        await triggerDeploy(env, sites);
+        await triggerDeploy(env, sitesToDeploy);
         deployStatus = "triggered";
       } catch (err) {
         deployStatus = `error: ${err}`;


### PR DESCRIPTION
## Purpose

This bugfix ensures that GitHub Actions site rebuilds are triggered correctly when a published post is updated to remove a site, or when a published post is deleted. Previously, removed sites were never rebuilt (leaving the post visible) and deleting a published post triggered no rebuild at all.

## Key Changes

- In the PUT handler, read existing site assignments before replacing them, then fire `triggerDeploy` with the union of old and new sites — ensuring removed sites get rebuilt
- The DELETE handler (already fixed on main) correctly reads sites and post status before deletion and triggers a deploy only for published posts with site assignments

## Checks

- [ ] Code compiles without errors
- [ ] Changes have been tested locally
- [ ] No console.log or debug statements left behind
- [ ] Types are properly defined

## Task

[#24](https://github.com/jordandevogelaere/filipvanbergen/issues/24)