### PR TITLE
#26 - Build failed

### DIFF
--- a/admin/src/app/api/posts/[id]/route.ts
+++ b/admin/src/app/api/posts/[id]/route.ts
@@ -154,7 +154,7 @@ export async function PUT(
       .prepare("SELECT site FROM post_sites WHERE post_id = ?1")
       .bind(id)
       .all<{ site: string }>();
-    const oldSites = oldSitesResult.results.map((r) => r.site);
+    const oldSites = oldSitesResult.results.map((r: { site: string }) => r.site);
 
     // Replace site assignments
     await db.prepare("DELETE FROM post_sites WHERE post_id = ?1").bind(id).run();


### PR DESCRIPTION
## Purpose

This bugfix resolves a TypeScript build failure caused by an implicit `any` type on a map callback parameter. The D1 `.all<T>()` generic type does not propagate into downstream `.map()` callbacks, so TypeScript's `noImplicitAny` check rejects the build.

## Key Changes

- Added explicit `{ site: string }` type annotation on the `.map()` callback in the `PUT /api/posts/[id]` route to satisfy TypeScript's strict type checking

## Checks

- [x] Code compiles without errors
- [x] Changes have been tested locally

## Task

[#26](https://github.com/jordandevogelaere/filipvanbergen/issues/26)