### PR TITLE
#28 - Fix social share links to show correct URL per published site

### DIFF
--- a/admin/src/components/PostForm.tsx
+++ b/admin/src/components/PostForm.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import { Save, Eye, EyeOff, Globe, Send, Upload, X } from "lucide-react";
-import { LOCALES, SITES, type Locale } from "@/lib/types";
+import { LOCALES, SITES, SITE_URLS, type Locale, type Site } from "@/lib/types";
 import SocialShareButtons from "./SocialShareButtons";
 import { useToast } from "./ToastProvider";
 
@@ -58,7 +58,6 @@ export default function PostForm({ postId, initialData }: PostFormProps) {
   const [saving, setSaving] = useState(false);
   const [publishing, setPublishing] = useState(false);
   const [uploading, setUploading] = useState(false);
-  const [showShareButtons, setShowShareButtons] = useState(false);
   const toast = useToast();
 
   function updateTranslation(
@@ -122,7 +121,6 @@ export default function PostForm({ postId, initialData }: PostFormProps) {
 
       if (publish) {
         setIsPublished(true);
-        setShowShareButtons(true);
         toast.success(postId ? "Post updated successfully" : "Post published successfully");
       } else {
         toast.success(isPublished ? "Post unpublished" : "Draft saved");
@@ -137,31 +135,8 @@ export default function PostForm({ postId, initialData }: PostFormProps) {
     }
   }
 
-  // Build the post URL for social sharing
-  const postUrl = slug
-    ? `https://www.fvbadvocaten.com/nl/blog/${slug}/`
-    : "";
-
   return (
     <div className="space-y-6">
-      {showShareButtons && (
-        <div className="bg-green-50 border border-green-200 rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-green-800 mb-2">
-            Post Published!
-          </h3>
-          <p className="text-sm text-green-700 mb-4">
-            Share this post on social media:
-          </p>
-          <SocialShareButtons url={postUrl} title={translations.nl.title} />
-          <button
-            onClick={() => router.push("/posts")}
-            className="mt-4 text-sm text-green-700 underline"
-          >
-            Back to posts
-          </button>
-        </div>
-      )}
-
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Main content area */}
         <div className="lg:col-span-2 space-y-6">
@@ -391,6 +366,23 @@ export default function PostForm({ postId, initialData }: PostFormProps) {
           </div>
         </div>
       </div>
+
+      {isPublished && slug && selectedSites.length > 0 && (
+        <div className="bg-white rounded-xl shadow-sm border border-steel-200 p-6 space-y-4">
+          <h3 className="text-base font-semibold text-navy-800">Share Links</h3>
+          {selectedSites.map((site) => (
+            <div key={site}>
+              <p className="text-sm font-medium text-navy-700 mb-2">
+                {SITES.find((s) => s.value === site)?.label ?? site}
+              </p>
+              <SocialShareButtons
+                url={`${SITE_URLS[site as Site]}/nl/blog/${slug}/`}
+                title={translations.nl.title}
+              />
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/admin/src/components/SocialShareButtons.tsx
+++ b/admin/src/components/SocialShareButtons.tsx
@@ -47,29 +47,32 @@ export default function SocialShareButtons({
   }
 
   return (
-    <div className="flex flex-wrap gap-3">
-      <button
-        onClick={handleCopy}
-        className="flex items-center gap-2 px-4 py-2 bg-steel-200 text-navy-700 rounded-lg text-sm font-medium hover:bg-steel-300 transition-colors"
-      >
-        {copied ? (
-          <Check className="w-4 h-4 text-green-600" />
-        ) : (
-          <Copy className="w-4 h-4" />
-        )}
-        {copied ? "Copied!" : "Copy URL"}
-      </button>
-
-      {platforms.map((platform) => (
+    <div>
+      <p className="text-xs font-mono text-navy-500 break-all mb-3">{url}</p>
+      <div className="flex flex-wrap gap-3">
         <button
-          key={platform.name}
-          onClick={() => handleShare(platform)}
-          className={`flex items-center gap-2 px-4 py-2 ${platform.color} text-white rounded-lg text-sm font-medium hover:opacity-90 transition-opacity`}
+          onClick={handleCopy}
+          className="flex items-center gap-2 px-4 py-2 bg-steel-200 text-navy-700 rounded-lg text-sm font-medium hover:bg-steel-300 transition-colors"
         >
-          <ExternalLink className="w-4 h-4" />
-          {platform.name}
+          {copied ? (
+            <Check className="w-4 h-4 text-green-600" />
+          ) : (
+            <Copy className="w-4 h-4" />
+          )}
+          {copied ? "Copied!" : "Copy URL"}
         </button>
-      ))}
+
+        {platforms.map((platform) => (
+          <button
+            key={platform.name}
+            onClick={() => handleShare(platform)}
+            className={`flex items-center gap-2 px-4 py-2 ${platform.color} text-white rounded-lg text-sm font-medium hover:opacity-90 transition-opacity`}
+          >
+            <ExternalLink className="w-4 h-4" />
+            {platform.name}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/admin/src/lib/types.ts
+++ b/admin/src/lib/types.ts
@@ -9,6 +9,11 @@ export const SITES: { value: Site; label: string }[] = [
   { value: "fvbmediation", label: "FVB Mediation" },
   { value: "fvbarbitration", label: "FVB Arbitration" },
 ];
+export const SITE_URLS: Record<Site, string> = {
+  fvbadvocaten: "https://www.fvbadvocaten.com",
+  fvbmediation: "https://www.fvbmediation.com",
+  fvbarbitration: "https://www.fvbarbitration.com",
+};
 export const PLATFORMS: { value: Platform; label: string }[] = [
   { value: "linkedin", label: "LinkedIn" },
   { value: "twitter", label: "X (Twitter)" },


### PR DESCRIPTION
## Purpose

This feature replaces the transient post-publish green overlay (which disappeared on navigation) with a permanent Share Links section at the bottom of the post form. It also fixes the hardcoded URL so each selected site shows its correct domain instead of always showing `fvbadvocaten.com`.

## Key Changes

- Add `SITE_URLS` constant in `types.ts` mapping each `Site` value to its base domain
- Remove `showShareButtons` state and the transient green overlay from `PostForm`
- Add a permanent **Share Links** section rendered whenever `isPublished && slug && selectedSites.length > 0`
- Each site block renders its own `SocialShareButtons` with the correct per-site URL (`SITE_URLS[site]/nl/blog/${slug}/`)
- Display the full URL as readable monospace text above the share buttons in `SocialShareButtons` so users can verify before clicking

## Checks

- [ ] Code compiles without errors
- [ ] Changes have been tested locally
- [ ] No `console.log` or debug statements left behind
- [ ] Types are properly defined (no `any` unless justified)

## Task

[#28](https://github.com/jordandevogelaere/filipvanbergen/issues/28)